### PR TITLE
Allow override of BSA path

### DIFF
--- a/tpm_futurepcr/__init__.py
+++ b/tpm_futurepcr/__init__.py
@@ -21,6 +21,8 @@ def main():
                         help="write binary PCR values to specified file")
     parser.add_argument("--allow-unexpected-bsa", action="store_true",
                         help="accept BOOT_SERVICES_APPLICATION events with weird paths")
+    parser.add_argument("--substitute-bsa-unix-path", action=KeyValueAction,
+                        help="substitute BOOT_SERVICES_APPLICATION path (syntax: <computed unix path>=<new unix path>)")
     parser.add_argument("--compare", action="store_true",
                         help="compare computed PCRs against live values")
     parser.add_argument("-v", "--verbose", action="store_true",
@@ -91,6 +93,8 @@ def main():
             event_data = parse_efi_bsa_event(event["event_data"])
             try:
                 unix_path = device_path_to_unix_path(event_data["device_path_vec"])
+                if args.substitute_bsa_unix_path:
+                    unix_path = args.substitute_bsa_unix_path.get(unix_path, unix_path)
             except Exception as e:
                 print(e)
                 errors = 1

--- a/tpm_futurepcr/util.py
+++ b/tpm_futurepcr/util.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import signify.fingerprinter
 import subprocess
+import argparse
 
 def to_hex(buf):
     import binascii
@@ -119,3 +120,16 @@ def find_mountpoint_by_partuuid(partuuid):
                          stdout=subprocess.PIPE)
     res.check_returncode()
     return res.stdout.splitlines()[0].decode()
+
+class KeyValueAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if getattr(namespace, self.dest, None) is None:
+            setattr(namespace, self.dest, dict())
+        kvmap = getattr(namespace, self.dest)
+        if not isinstance(values, list):
+            values = [ values ]
+        kvpairs = [ v.split('=', 1) for v in values ]
+        try:
+            kvmap.update(kvpairs)
+        except ValueError:
+            raise argparse.ArgumentTypeError("Value for option %s malformed: %s" % (self.dest, values))


### PR DESCRIPTION
- Add argument `--override-bsa-path` whose value is the path to an
  alternative object to be used in measurements for events of type
  EFI_BOOT_SERVICES_APPLICATION.