### PR TITLE
Introduced classes for different kinds of events

### DIFF
--- a/tests/integration/test_tpm_futurepcr.py
+++ b/tests/integration/test_tpm_futurepcr.py
@@ -53,8 +53,9 @@ class TestTPM_FuturePCR(unittest.TestCase):
 
         pcr_list = [0, 1, 2, 3]
         with patch("builtins.open", seq_mock_open(file_mocks)), \
-             patch("os.path.exists", side_effect=[True]):
-            this_pcrs, next_pcrs, errors = process_log(pcr_list, TpmAlgorithm.SHA256, Path("/unused"), None, False)
+             patch("os.path.exists", side_effect=[True]), \
+             patch("tpm_futurepcr.LogEvent.find_mountpoint_by_partuuid", return_value='/'):
+            this_pcrs, next_pcrs = process_log(pcr_list, TpmAlgorithm.SHA256, Path("/unused"), dict(), False)
             self.assertFalse(compare_pcrs("sha256", this_pcrs, next_pcrs, pcr_list))
 
     def test_replay_compare_eventlog_tpm2_BIOS_ROM_ACTUAL(self):
@@ -66,22 +67,24 @@ class TestTPM_FuturePCR(unittest.TestCase):
                 file_mocks.append(f.read())
 
         with patch("builtins.open", seq_mock_open(file_mocks)), \
-             patch("os.path.exists", side_effect=[True]):
+             patch("os.path.exists", side_effect=[True]), \
+             patch("tpm_futurepcr.LogEvent.find_mountpoint_by_partuuid", return_value='/'):
             pcr_list = [0, 1, 2, 3]
             for tst in tests:
                 with self.subTest("Test actual log", tst=basename(tst.name)):
-                    _, _, errors = process_log(pcr_list, TpmAlgorithm.SHA256, Path("/unused"), None, False)
+                    process_log(pcr_list, TpmAlgorithm.SHA256, Path("/unused"), dict(), False)
 
     def test_replay_eventlog_tpm2_PCR12_ROM_ACTUAL(self):
         logging.basicConfig(level=logging.DEBUG)
         file_mocks = []
         with open("tests/fixtures/ACTUAL_SYSTEMS/Dell_Optiplex_TPM2.0_UEFI_NonSB_Linux.log", "rb") as f:
             file_mocks.append(f.read())
-        file_mocks.extend([FileNotFoundError, FileNotFoundError])
+        file_mocks.append(FileNotFoundError)
 
         with patch("builtins.open", seq_mock_open(file_mocks)), \
              patch("os.path.exists", side_effect=[True]), \
-             patch("tpm_futurepcr.device_path.find_mountpoint_by_partuuid", side_effect=['/', '/']), \
+             patch("tpm_futurepcr.LogEvent.find_mountpoint_by_partuuid", return_value='/'), \
              patch("tpm_futurepcr.loader_get_next_cmdline", side_effect=[r'initrd=\intel-ucode.img initrd=\initramfs-linux.img rd.luks.name=0154ed05-bf69-4f1c-b74a-46f05048d78e=sys root=/dev/mapper/sys rw audit=0 i915.fastboot=1 net.ifnames=0']):
             pcr_list = [12]
-            _, _, errors = process_log(pcr_list, TpmAlgorithm.SHA256, Path("/unused"), None, False)
+            with self.assertRaises(ValueError):
+                process_log(pcr_list, TpmAlgorithm.SHA256, Path("/unused"), dict(), False)

--- a/tpm_futurepcr.py
+++ b/tpm_futurepcr.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     parser.add_argument("-H", "--hash-alg", help="specify the hash algorithm", choices=_HASH_ALG_CHOICES)
     parser.add_argument("-o", "--output", type=Path, help="write binary PCR values to specified file")
     parser.add_argument("--allow-unexpected-bsa", action="store_true", help="accept BOOT_SERVICES_APPLICATION events with weird paths")
-    parser.add_argument("--substitute-bsa-unix-path", action=KeyValueAction, help="substitute BOOT_SERVICES_APPLICATION path (syntax: <computed unix path>=<new unix path>)")
+    parser.add_argument("--substitute-bsa-unix-path", action=KeyValueAction, default=dict(), help="substitute BOOT_SERVICES_APPLICATION path (syntax: <computed unix path>=<new unix path>)")
     parser.add_argument("--compare", action="store_true", help="compare computed PCRs against live values")
     parser.add_argument("--log-path", type=Path, help="read binary log from an alternative path")
 
@@ -90,9 +90,10 @@ if __name__ == "__main__":
     args = postprocess_args(parser.parse_args())
 
     # process the event log
-    this_pcrs, next_pcrs, errors = process_log(args.pcr_list, args.hash_alg, args.log_path, args.substitute_bsa_unix_path, args.allow_unexpected_bsa)
-    if errors:
-        logger.error("fatal errors occured")
+    try:
+        this_pcrs, next_pcrs = process_log(args.pcr_list, args.hash_alg, args.log_path, args.substitute_bsa_unix_path, args.allow_unexpected_bsa)
+    except ValueError:
+        logger.error('Because of previous exceptions, the program is terminating')
         exit(1)
 
     # if requested, compare the pcr values and exist if different

--- a/tpm_futurepcr/LogEvent.py
+++ b/tpm_futurepcr/LogEvent.py
@@ -1,12 +1,17 @@
+import hashlib
+from abc import abstractmethod, ABC
 from dataclasses import dataclass, InitVar, field
 import dataclasses
+from pathlib import Path
 from pprint import pformat
 from typing import Any
 
+import signify
+
 from .device_path import parse_efi_device_path
-from .tpm_constants import TpmEventType, TpmAlgorithm
+from .tpm_constants import TpmEventType, TpmAlgorithm, DevicePathType, MediaDevicePathSubtype
 from . import logging
-from .util import hexdump, guid_to_UUID
+from .util import hexdump, guid_to_UUID, find_mountpoint_by_partuuid
 from .binary_reader import BinaryReader
 
 logger = logging.getLogger('log_event')
@@ -17,23 +22,55 @@ logger = logging.getLogger('log_event')
 # TPMv2: https://trustedcomputinggroup.org/wp-content/uploads/EFI-Protocol-Specification-rev13-160330final.pdf
 
 
-@dataclass(frozen=True)
-class EFIBSAData:
-    image_location: int
-    image_length: int
-    image_lt_address: int
-    device_path_vec: list[Any]
-
-
 @dataclass
-class LogEvent:
+class BaseEvent(ABC):
     binary_reader: InitVar[BinaryReader]
     tpm_version: InitVar[int]
     tcg_hdr: InitVar[dict | None]
-    pcr_idx: int = field(init=False)
-    type: TpmEventType = field(init=False)
+    pcr_idx: int
+    type: TpmEventType
     pcr_extend_values: dict[TpmAlgorithm, bytes] = field(init=False)
-    data: bytes | EFIBSAData = field(init=False)
+    data: bytes = field(init=False)
+
+    def __post_init__(self, binary_reader: BinaryReader, tpm_version: int, tcg_hdr: dict | None):
+        self.pcr_extend_values = dict()
+        # same across both formats
+        if tpm_version == 1:
+            # section 5.1, SHA1 Event Log Entry Format
+            self.pcr_extend_values[TpmAlgorithm.SHA1] = binary_reader.read(20)
+        elif tpm_version == 2:
+            # section 5.2, Crypto Agile Log Entry Format
+            pcr_count = binary_reader.read_u32()
+            for i in range(pcr_count):
+                # Spec says it should be safe to just iter over hdr[digest_sizes],
+                # as all entries must have the same algorithms in the same order,
+                # but it does recommend alg_id lookup as the preferred method.
+                _alg = binary_reader.read_u16()
+                alg_id = TpmAlgorithm(_alg)
+                self.pcr_extend_values[alg_id] = binary_reader.read(tcg_hdr["digest_sizes_dict"][alg_id])
+        self._read_data(binary_reader)
+
+    @abstractmethod
+    def _read_data(self, binary_reader: BinaryReader):
+        pass
+
+    @abstractmethod
+    def next_extend_value(self, current_extend_value: bytes, hash_alg: str = "sha1") -> bytes:
+        pass
+
+
+@dataclass
+class GenericEvent(BaseEvent):
+
+    def __post_init__(self, binary_reader: BinaryReader, tpm_version: int, tcg_hdr: dict | None):
+        super().__post_init__(binary_reader, tpm_version, tcg_hdr)
+
+    def _read_data(self, binary_reader: BinaryReader):
+        event_size = binary_reader.read_u32()
+        self.data = binary_reader.read(event_size)
+
+    def next_extend_value(self, current_extend_value: bytes, hash_alg: str = "sha1") -> bytes:
+        return current_extend_value
 
     @staticmethod
     def _parse_efi_variable_event(data):
@@ -51,20 +88,7 @@ class LogEvent:
 
     def show(self):
         logger.verbose("\033[1mPCR %d -- Event <%s>\033[m", self.pcr_idx, self.type.name)
-        if self.type == TpmEventType.EFI_BOOT_SERVICES_APPLICATION:
-            if logger.level == logging.DEBUG:
-                for i in hexdump(self.data):
-                    logger.debug(i)
-                ed = dataclasses.asdict(self.data)
-                logger.debug(pformat(ed))
-            else:
-                logger.verbose("Path vector:")
-                for p in self.data.device_path_vec:
-                    type_name = getattr(p["type"], "name", str(p["type"]))
-                    subtype_name = getattr(p["subtype"], "name", str(p["subtype"]))
-                    file_path = p.get("file_path", p["data"])
-                    logger.verbose("  * %-20s %-20s %s", type_name, subtype_name, file_path)
-        elif self.type in {TpmEventType.EFI_VARIABLE_AUTHORITY,
+        if self.type in {TpmEventType.EFI_VARIABLE_AUTHORITY,
                             TpmEventType.EFI_VARIABLE_BOOT,
                             TpmEventType.EFI_VARIABLE_DRIVER_CONFIG}:
             if logger.level == logging.DEBUG:
@@ -79,33 +103,96 @@ class LogEvent:
             for i in hexdump(self.data, 64):
                 logger.debug(i)
 
-    def __post_init__(self, binary_reader, tpm_version, tcg_hdr):
-        self.pcr_idx = binary_reader.read_u32()
-        self.type = TpmEventType(binary_reader.read_u32())
-        self.pcr_extend_values = dict()
-        # same across both formats
-        if tpm_version == 1:
-            # section 5.1, SHA1 Event Log Entry Format
-            self.pcr_extend_values[TpmAlgorithm.SHA1] = binary_reader.read(20)
-        elif tpm_version == 2:
-            # section 5.2, Crypto Agile Log Entry Format
-            pcr_count = binary_reader.read_u32()
-            for i in range(pcr_count):
-                # Spec says it should be safe to just iter over hdr[digest_sizes],
-                # as all entries must have the same algorithms in the same order,
-                # but it does recommend alg_id lookup as the preferred method.
-                _alg = binary_reader.read_u16()
-                alg_id = TpmAlgorithm(_alg)
-                self.pcr_extend_values[alg_id] = binary_reader.read(tcg_hdr["digest_sizes_dict"][alg_id])
 
-        # same across both formats
-        event_size = binary_reader.read_u32()
-        if self.type == TpmEventType.EFI_BOOT_SERVICES_APPLICATION:
-            image_location = binary_reader.read_ptr()     # EFI_PHYSICAL_ADDRESS (pointer)
-            image_length = binary_reader.read_size()      # UINTN (u64/u32 depending on arch)
-            image_lt_address = binary_reader.read_size()  # UINTN
-            device_path_len = binary_reader.read_size()   # UINTN
-            device_path_vec = parse_efi_device_path(binary_reader.read(device_path_len))
-            self.data = EFIBSAData(image_location, image_length, image_lt_address, device_path_vec)
+@dataclass(frozen=True)
+class _EFIBSAData:
+    image_location: int
+    image_length: int
+    image_lt_address: int
+    device_path_vec: list[Any]
+
+
+@dataclass
+class EFIBSAEvent(BaseEvent):
+    substitute_bsa_unix_path: dict
+    allow_unexpected_bsa: bool
+    unix_path: Path = field(init=False, default=None)
+    data: _EFIBSAData = field(init=False)
+
+    def __post_init__(self, binary_reader, tpm_version, tcg_hdr):
+        super().__post_init__(binary_reader, tpm_version, tcg_hdr)
+
+    def _read_data(self, binary_reader: BinaryReader):
+        # the first 4 bytes are always the event size
+        binary_reader.read_u32()
+
+        # same across both format
+        image_location = binary_reader.read_ptr()     # EFI_PHYSICAL_ADDRESS (pointer)
+        image_length = binary_reader.read_size()      # UINTN (u64/u32 depending on arch)
+        image_lt_address = binary_reader.read_size()  # UINTN
+        device_path_len = binary_reader.read_size()   # UINTN
+        device_path_vec = parse_efi_device_path(binary_reader.read(device_path_len))
+        self.data = _EFIBSAData(image_location, image_length, image_lt_address, device_path_vec)
+
+        unix_path = self._device_path_to_unix_path()
+        if unix_path is None:
+            # This might be a firmware item such as the boot menu.
+            if not self.allow_unexpected_bsa:
+                logger.error("Unexpected boot events found. Binding to these PCR values "
+                             "is not advised, as it might be difficult to reproduce this state "
+                             "later. Exiting.")
+                exit(1)
+            logger.warning("couldn't map EfiBootServicesApplication event to a Linux path")
+        self.unix_path = self.substitute_bsa_unix_path.get(unix_path, unix_path)
+
+    def _device_path_to_unix_path(self) -> Path | None:
+        dir_path = None
+        unix_path = None
+        for pp in self.data.device_path_vec:
+            if pp.type == DevicePathType.MediaDevice:
+                if pp.subtype == MediaDevicePathSubtype.HardDrive:
+                    dir_path = find_mountpoint_by_partuuid(pp.part_uuid)
+                    if not dir_path:
+                        raise Exception("could not find mountpoint for partuuid %r" % pp.part_uuid)
+                if pp.subtype == MediaDevicePathSubtype.FilePath:
+                    unix_path = dir_path / Path(pp.file_path)
+            if pp.type == DevicePathType.End:
+                break
+        return unix_path
+
+    def show(self):
+        if logger.level == logging.DEBUG:
+            for i in hexdump(self.data):
+                logger.debug(i)
+            ed = dataclasses.asdict(self.data)
+            logger.debug(pformat(ed))
         else:
-            self.data = binary_reader.read(event_size)
+            logger.verbose("Path vector:")
+            for p in self.data.device_path_vec:
+                type_name = getattr(p["type"], "name", str(p["type"]))
+                subtype_name = getattr(p["subtype"], "name", str(p["subtype"]))
+                file_path = p.get("file_path", p["data"])
+                logger.verbose("  * %-20s %-20s %s", type_name, subtype_name, file_path)
+
+    def _hash_pecoff(self, hash_alg="sha1"):
+        try:
+            with open(self.unix_path, "rb") as fh:
+                fpr = signify.fingerprinter.AuthenticodeFingerprinter(fh)
+                fpr.add_authenticode_hashers(getattr(hashlib, hash_alg))
+                return fpr.hash()[hash_alg]
+        except FileNotFoundError:
+            logger.info("File %s could not be opened. Continuing with the log-provided extend value", self.unix_path)
+            raise ValueError
+
+    def next_extend_value(self, current_extend_value: bytes, hash_alg: str = "sha1") -> bytes:
+        return self._hash_pecoff(hash_alg)
+
+
+def logEventFactory(binary_reader, tpm_version, tcg_hdr, substitute_bsa_unix_path, allow_unexpected_bsa):
+    pcr_idx = binary_reader.read_u32()
+    type = TpmEventType(binary_reader.read_u32())
+
+    if type == TpmEventType.EFI_BOOT_SERVICES_APPLICATION:
+        return EFIBSAEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type, substitute_bsa_unix_path, allow_unexpected_bsa)
+    else:
+        return GenericEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type)

--- a/tpm_futurepcr/device_path.py
+++ b/tpm_futurepcr/device_path.py
@@ -1,9 +1,7 @@
 # https://github.com/tianocore/edk2/blob/master/MdePkg/Include/Protocol/DevicePath.h
-from pathlib import Path
 
 from .binary_reader import BinaryReader
 from .tpm_constants import *
-from .util import find_mountpoint_by_partuuid
 
 class Parseable():
     @classmethod
@@ -67,19 +65,3 @@ class DevicePath(list, Parseable):
 def parse_efi_device_path(buf):
     buf = BinaryReader(buf)
     return DevicePath.parse(buf)
-
-
-def device_path_to_unix_path(path_vec) -> Path | None:
-    dir_path = None
-    unix_path = None
-    for pp in path_vec:
-        if pp.type == DevicePathType.MediaDevice:
-            if pp.subtype == MediaDevicePathSubtype.HardDrive:
-                dir_path = find_mountpoint_by_partuuid(pp.part_uuid)
-                if not dir_path:
-                    raise Exception("could not find mountpoint for partuuid %r" % pp.part_uuid)
-            if pp.subtype == MediaDevicePathSubtype.FilePath:
-                unix_path = dir_path / Path(pp.file_path)
-        if pp.type == DevicePathType.End:
-            break
-    return unix_path

--- a/tpm_futurepcr/util.py
+++ b/tpm_futurepcr/util.py
@@ -4,8 +4,6 @@ import subprocess as sp
 import uuid
 from pathlib import Path
 
-import signify.fingerprinter
-
 from .binary_reader import BinaryReader
 
 import tpm_futurepcr.logging as logging
@@ -61,14 +59,6 @@ def hash_file(path, alg="sha1"):
             buf = fh.read(buf_size)
             h.update(buf)
     return h.digest()
-
-
-def hash_pecoff(path, alg="sha1"):
-    with open(path, "rb") as fh:
-        fpr = signify.fingerprinter.AuthenticodeFingerprinter(fh)
-        fpr.add_authenticode_hashers(getattr(hashlib, alg))
-        return fpr.hash()[alg]
-    return None
 
 
 def read_pecoff_section(path: Path, section: bytes):


### PR DESCRIPTION
This PR provides the encapsulation of events on their own classes (currently a base class, a generic and and EFIBSA), which provide access to the specific methods they require.

Note: I am having an issue, related to the QEMU test. It is failing because there is an EFIBSA event that only contains the MediaDevicePathSubtype.FilePath subtype, but not the MediaDevicePathSubtype.HardDrive. Might you know if this is a bug in QEMU or is a legitimate situation? How should it be handled?