### PR TITLE
Encapsulation of remaining events in their own classes

### DIFF
--- a/tests/integration/test_tpm_futurepcr.py
+++ b/tests/integration/test_tpm_futurepcr.py
@@ -79,12 +79,11 @@ class TestTPM_FuturePCR(unittest.TestCase):
         file_mocks = []
         with open("tests/fixtures/ACTUAL_SYSTEMS/Dell_Optiplex_TPM2.0_UEFI_NonSB_Linux.log", "rb") as f:
             file_mocks.append(f.read())
-        file_mocks.append(FileNotFoundError)
+        file_mocks.extend([FileNotFoundError, FileNotFoundError])
 
         with patch("builtins.open", seq_mock_open(file_mocks)), \
              patch("os.path.exists", side_effect=[True]), \
              patch("tpm_futurepcr.LogEvent.find_mountpoint_by_partuuid", return_value='/'), \
-             patch("tpm_futurepcr.loader_get_next_cmdline", side_effect=[r'initrd=\intel-ucode.img initrd=\initramfs-linux.img rd.luks.name=0154ed05-bf69-4f1c-b74a-46f05048d78e=sys root=/dev/mapper/sys rw audit=0 i915.fastboot=1 net.ifnames=0']):
+             patch("tpm_futurepcr.LogEvent.loader_get_next_cmdline", side_effect=[r'initrd=\intel-ucode.img initrd=\initramfs-linux.img rd.luks.name=0154ed05-bf69-4f1c-b74a-46f05048d78e=sys root=/dev/mapper/sys rw audit=0 i915.fastboot=1 net.ifnames=0']):
             pcr_list = [12]
-            with self.assertRaises(ValueError):
-                process_log(pcr_list, TpmAlgorithm.SHA256, Path("/unused"), dict(), False)
+            process_log(pcr_list, TpmAlgorithm.SHA256, Path("/unused"), dict(), False)

--- a/tpm_futurepcr.py
+++ b/tpm_futurepcr.py
@@ -8,10 +8,10 @@ from tpm_futurepcr import to_hex, process_log, compare_pcrs, possibly_unused_ban
 import tpm_futurepcr.logging as logging
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-logger = logging.getLogger('tpm_futurepcr')
+logger = logging.getLogger("tpm_futurepcr")
 
 
-_HASH_ALG_CHOICES = ['sha1', 'sha256']
+_HASH_ALG_CHOICES = ["sha1", "sha256"]
 _PCRS_MAX_NUM = 24
 
 

--- a/tpm_futurepcr/LogEvent.py
+++ b/tpm_futurepcr/LogEvent.py
@@ -13,6 +13,7 @@ from .tpm_constants import TpmEventType, TpmAlgorithm, DevicePathType, MediaDevi
 from . import logging
 from .util import hexdump, guid_to_UUID, find_mountpoint_by_partuuid
 from .binary_reader import BinaryReader
+from .systemd_boot import loader_encode_pcr8, loader_decode_pcr8, loader_get_next_cmdline
 
 logger = logging.getLogger('log_event')
 
@@ -20,6 +21,13 @@ logger = logging.getLogger('log_event')
 # ~/src/linux/include/linux/tpm_eventlog.h
 # TPMv1: https://sources.debian.org/src/golang-github-coreos-go-tspi/0.1.1-2/tspi/tpm.go/?hl=44#L44
 # TPMv2: https://trustedcomputinggroup.org/wp-content/uploads/EFI-Protocol-Specification-rev13-160330final.pdf
+
+
+class PCRBankNotUpdated(Exception):
+    pass
+
+class EFIBSAEventException(Exception):
+    pass
 
 
 @dataclass
@@ -55,7 +63,7 @@ class BaseEvent(ABC):
         pass
 
     @abstractmethod
-    def next_extend_value(self, current_extend_value: bytes, hash_alg: str = "sha1") -> bytes:
+    def next_extend_value(self, hash_alg: TpmAlgorithm = TpmAlgorithm.SHA1) -> bytes:
         pass
 
     @abstractmethod
@@ -73,8 +81,45 @@ class GenericEvent(BaseEvent):
         event_size = binary_reader.read_u32()
         self.data = binary_reader.read(event_size)
 
-    def next_extend_value(self, current_extend_value: bytes, hash_alg: str = "sha1") -> bytes:
-        return current_extend_value
+    def next_extend_value(self, hash_alg: TpmAlgorithm = TpmAlgorithm.SHA1) -> bytes:
+        return self.pcr_extend_values[hash_alg]
+
+    def show(self):
+        logger.verbose("\033[1mPCR %d -- Event <%s>\033[m", self.pcr_idx, self.type.name)
+        for i in hexdump(self.data, 64):
+            logger.debug(i)
+
+
+@dataclass
+class NoActionEvent(BaseEvent):
+
+    def __post_init__(self, binary_reader: BinaryReader, tpm_version: int, tcg_hdr: dict | None):
+        super().__post_init__(binary_reader, tpm_version, tcg_hdr)
+
+    def _read_data(self, binary_reader: BinaryReader):
+        event_size = binary_reader.read_u32()
+        self.data = binary_reader.read(event_size)
+
+    def next_extend_value(self, hash_alg: TpmAlgorithm = TpmAlgorithm.SHA1) -> bytes:
+        return self.pcr_extend_values[hash_alg]
+
+    def show(self):
+        logger.verbose("\033[1mPCR %d -- Event <%s>\033[m", self.pcr_idx, self.type.name)
+        for i in hexdump(self.data, 64):
+            logger.debug(i)
+
+
+@dataclass
+class EFIVarEvent(BaseEvent):
+    def __post_init__(self, binary_reader: BinaryReader, tpm_version: int, tcg_hdr: dict | None):
+        super().__post_init__(binary_reader, tpm_version, tcg_hdr)
+
+    def _read_data(self, binary_reader: BinaryReader):
+        event_size = binary_reader.read_u32()
+        self.data = binary_reader.read(event_size)
+
+    def next_extend_value(self, hash_alg: TpmAlgorithm = TpmAlgorithm.SHA1) -> bytes:
+        return self.pcr_extend_values[hash_alg]
 
     @staticmethod
     def _parse_efi_variable_event(data):
@@ -92,20 +137,14 @@ class GenericEvent(BaseEvent):
 
     def show(self):
         logger.verbose("\033[1mPCR %d -- Event <%s>\033[m", self.pcr_idx, self.type.name)
-        if self.type in {TpmEventType.EFI_VARIABLE_AUTHORITY,
-                            TpmEventType.EFI_VARIABLE_BOOT,
-                            TpmEventType.EFI_VARIABLE_DRIVER_CONFIG}:
-            if logger.level == logging.DEBUG:
-                for i in hexdump(self.data, 64):
-                    logger.debug(i)
-                ed = self._parse_efi_variable_event(self.data)
-                logger.debug(pformat(ed))
-            else:
-                ed = self._parse_efi_variable_event(self.data)
-                logger.verbose("Variable: %r {%s}", ed["unicode_name"], ed["variable_name_uuid"])
-        else:
+        if logger.level == logging.DEBUG:
             for i in hexdump(self.data, 64):
                 logger.debug(i)
+            ed = self._parse_efi_variable_event(self.data)
+            logger.debug(pformat(ed))
+        else:
+            ed = self._parse_efi_variable_event(self.data)
+            logger.verbose("Variable: %r {%s}", ed["unicode_name"], ed["variable_name_uuid"])
 
 
 @dataclass(frozen=True)
@@ -114,10 +153,6 @@ class _EFIBSAData:
     image_length: int
     image_lt_address: int
     device_path_vec: list[Any]
-
-
-class EFIBSAEventException(Exception):
-    pass
 
 
 @dataclass
@@ -185,25 +220,76 @@ class EFIBSAEvent(BaseEvent):
                 file_path = p.get("file_path", p["data"])
                 logger.verbose("  * %-20s %-20s %s", type_name, subtype_name, file_path)
 
-    def _hash_pecoff(self, hash_alg="sha1"):
+    def next_extend_value(self, hash_alg: TpmAlgorithm = TpmAlgorithm.SHA1) -> bytes:
+        _hash_alg = hash_alg.name.lower()
         try:
             with open(self.unix_path, "rb") as fh:
                 fpr = AuthenticodeFingerprinter(fh)
-                fpr.add_authenticode_hashers(getattr(hashlib, hash_alg))
-                return fpr.hash()[hash_alg]
+                fpr.add_authenticode_hashers(getattr(hashlib, _hash_alg))
+                return fpr.hash()[_hash_alg]
         except FileNotFoundError:
-            logger.info("File %s could not be opened. Continuing with the log-provided extend value", self.unix_path)
-            raise ValueError
+            logger.info(
+                "File %s could not be opened. Continuing with the log-provided extend value",
+                self.unix_path)
+            return self.pcr_extend_values[hash_alg]
 
-    def next_extend_value(self, current_extend_value: bytes, hash_alg: str = "sha1") -> bytes:
-        return self._hash_pecoff(hash_alg)
+
+@dataclass
+class IPLEvent(BaseEvent):
+    # Handles systemd EFI stub "kernel command line" measurements (found in
+    # PCR 8 up to systemd v250, but PCR 12 afterwards).
+
+    last_efi_binary: Path = field(init=False)
+
+    def __post_init__(self, binary_reader: BinaryReader, tpm_version: int, tcg_hdr: dict | None):
+        super().__post_init__(binary_reader, tpm_version, tcg_hdr)
+
+    def _read_data(self, binary_reader: BinaryReader):
+        event_size = binary_reader.read_u32()
+        self.data = binary_reader.read(event_size)
+
+    def next_extend_value(self, hash_alg: TpmAlgorithm = TpmAlgorithm.SHA1) -> bytes:
+        try:
+            cmdline = loader_get_next_cmdline(self.last_efi_binary)
+        except FileNotFoundError:
+            # Either EFI variables, the ESP, or the .conf, are missing.
+            # It's probably not a systemd-boot environment, so PCR[8] meaning is undefined.
+            logger.verbose("-- not touching non-systemd IPL event --")
+            return self.pcr_extend_values[hash_alg]
+
+        if logger.level <= logging.VERBOSE:
+            old_cmdline = self.data
+            # 2022-03-19 grawity: In the past, we had to strip away the last \0 byte for
+            # some reason (which I don't remember)... but apparently now we don't? Let's
+            # add a warning so that hopefully I remember why it was necessary.
+            if len(old_cmdline) % 2 != 0:
+                logger.warning("Expecting EV_IPL data to contain UTF-16, but length isn't a multiple of 2")
+                old_cmdline += b'\0'
+            old_cmdline = loader_decode_pcr8(old_cmdline)
+            logger.verbose("-- extending with systemd-boot cmdline --")
+            logger.verbose("this cmdline: %s", old_cmdline)
+            logger.verbose("next cmdline: %s", cmdline)
+        cmdline = loader_encode_pcr8(cmdline)
+        return hashlib.new(hash_alg.name.lower(), cmdline).digest()
+
+    def show(self):
+        logger.verbose("\033[1mPCR %d -- Event <%s>\033[m", self.pcr_idx, self.type.name)
+        for i in hexdump(self.data, 64):
+            logger.debug(i)
 
 
-def LogEventFactory(binary_reader, tpm_version, tcg_hdr, substitute_bsa_unix_path, allow_unexpected_bsa) -> BaseEvent | None:
+def LogEventFactory(binary_reader, tpm_version, tcg_hdr, substitute_bsa_unix_path, allow_unexpected_bsa) -> BaseEvent:
     pcr_idx = binary_reader.read_u32()
     type = TpmEventType(binary_reader.read_u32())
 
-    if type == TpmEventType.EFI_BOOT_SERVICES_APPLICATION:
-        return EFIBSAEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type, substitute_bsa_unix_path, allow_unexpected_bsa)
-    else:
-        return GenericEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type)
+    match type:
+        case TpmEventType.EFI_BOOT_SERVICES_APPLICATION:
+            return EFIBSAEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type, substitute_bsa_unix_path, allow_unexpected_bsa)
+        case TpmEventType.EFI_VARIABLE_AUTHORITY | TpmEventType.EFI_VARIABLE_BOOT | TpmEventType.EFI_VARIABLE_DRIVER_CONFIG:
+            return EFIVarEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type)
+        case TpmEventType.IPL:
+            return IPLEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type)
+        case TpmEventType.NO_ACTION:
+            return NoActionEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type)
+        case _:
+            return GenericEvent(binary_reader, tpm_version, tcg_hdr, pcr_idx, type)

--- a/tpm_futurepcr/__init__.py
+++ b/tpm_futurepcr/__init__.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 from pathlib import Path
 
-from .LogEvent import EFIBSAEvent
+from .LogEvent import EFIBSAEvent, IPLEvent, NoActionEvent
 from .event_log import enum_log_entries
 from .pcr_bank import PcrBank, read_current_pcrs
-from .systemd_boot import loader_encode_pcr8, loader_decode_pcr8, loader_get_next_cmdline
 from .tpm_constants import TpmEventType, TpmAlgorithm
 import tpm_futurepcr.logging as logging
-from .util import to_hex, hash_bytes
+from .util import to_hex
 
-logger = logging.getLogger('tpm_futurepcr')
+logger = logging.getLogger("tpm_futurepcr")
 
 
 def process_log(wanted_pcrs: list[int], hash_alg: TpmAlgorithm, log_path: Path, substitute_bsa_unix_path: dict | None, allow_unexpected_bsa: bool):
@@ -17,22 +16,25 @@ def process_log(wanted_pcrs: list[int], hash_alg: TpmAlgorithm, log_path: Path, 
     next_pcrs = PcrBank(hash_alg.name.lower())
     last_efi_binary = None
 
+    # the set of pcrs request might be extended with additional the former depend upon
     required_pcrs = set(wanted_pcrs)
     if 12 in required_pcrs:
-        logger.verbose('Although not requested, PCR 4 is a dependency for PCR 12')
+        logger.verbose("Although not requested, PCR 4 is a dependency for PCR 12")
         required_pcrs.add(4)
 
+    verbose_pcr = logger.level <= logging.VERBOSE
+
+    # replay the events log
     for event in enum_log_entries(substitute_bsa_unix_path, allow_unexpected_bsa, log_path):
-        idx = event.pcr_idx
-        if idx not in required_pcrs:
+        if event.pcr_idx not in required_pcrs:
             continue
 
-        _verbose_pcr = logger.level <= logging.VERBOSE
-        if _verbose_pcr:
+        if verbose_pcr:
             event.show()
 
-        if idx == 0xFFFFFFFF:
-            if _verbose_pcr:
+        # if this event happens on the virtual PCR just skip it
+        if event.pcr_idx == 0xFFFFFFFF:
+            if verbose_pcr:
                 logger.verbose("event updates Windows virtual PCR[-1], skipping")
             continue
 
@@ -40,49 +42,28 @@ def process_log(wanted_pcrs: list[int], hash_alg: TpmAlgorithm, log_path: Path, 
             this_extend_value = event.pcr_extend_values[hash_alg]
             logger.verbose("this event extend value = %s", to_hex(this_extend_value))
         except KeyError:
-            if _verbose_pcr:
+            if verbose_pcr:
                 logger.verbose("event does not update the specified PCR bank, skipping")
             continue
 
-        # get the next extended value from the event
-        next_extend_value = event.next_extend_value(this_extend_value, hash_alg)
-        logger.verbose("guessed extend value = %s", to_hex(next_extend_value))
+        if isinstance(event, IPLEvent):
+            event.last_efi_binary = last_efi_binary
 
         if isinstance(event, EFIBSAEvent):
             last_efi_binary = event.unix_path
-            logger.verbose("extending with coff hash %s from path %s", to_hex(next_extend_value), event.unix_path)
+            logger.verbose("extending with coff hash from path %s", event.unix_path)
 
-        # Handle systemd EFI stub "kernel command line" measurements (found in
-        # PCR 8 up to systemd v250, but PCR 12 afterwards).
-        if event.type == TpmEventType.IPL and (idx in wanted_pcrs):
-            try:
-                cmdline = loader_get_next_cmdline(last_efi_binary)
-                if logger.level <= logging.VERBOSE:
-                    old_cmdline = event.data
-                    # 2022-03-19 grawity: In the past, we had to strip away the last \0 byte for
-                    # some reason (which I don't remember)... but apparently now we don't? Let's
-                    # add a warning so that hopefully I remember why it was necessary.
-                    if len(old_cmdline) % 2 != 0:
-                        logger.warning("Expecting EV_IPL data to contain UTF-16, but length isn't a multiple of 2")
-                        old_cmdline += b'\0'
-                    old_cmdline = loader_decode_pcr8(old_cmdline)
-                    logger.verbose("-- extending with systemd-boot cmdline --")
-                    logger.verbose("this cmdline: %s", old_cmdline)
-                    logger.verbose("next cmdline: %s", cmdline)
-                cmdline = loader_encode_pcr8(cmdline)
-                next_extend_value = hash_bytes(cmdline, hash_alg.name.lower())
-            except FileNotFoundError:
-                # Either EFI variables, the ESP, or the .conf, are missing.
-                # It's probably not a systemd-boot environment, so PCR[8] meaning is undefined.
-                logger.verbose("-- not touching non-systemd IPL event --")
+        # get the next extended value from the event
+        next_extend_value = event.next_extend_value(hash_alg)
+        logger.verbose("guessed extend value = %s", to_hex(next_extend_value))
 
-        if event.type != TpmEventType.NO_ACTION:
-            this_pcrs.extend_with_hash(idx, this_extend_value)
-            next_pcrs.extend_with_hash(idx, next_extend_value)
+        if not isinstance(event, NoActionEvent):
+            this_pcrs.extend_with_hash(event.pcr_idx, this_extend_value)
+            next_pcrs.extend_with_hash(event.pcr_idx, next_extend_value)
 
-        if _verbose_pcr:
-            logger.verbose("--> after this event, PCR %d contains value %s" % (idx, to_hex(this_pcrs[idx])))
-            logger.verbose("--> after reboot, PCR %d will contain value %s" % (idx, to_hex(next_pcrs[idx])))
+        if verbose_pcr:
+            logger.verbose("--> after this event, PCR %d contains value %s" % (event.pcr_idx, to_hex(this_pcrs[event.pcr_idx])))
+            logger.verbose("--> after reboot, PCR %d will contain value %s" % (event.pcr_idx, to_hex(next_pcrs[event.pcr_idx])))
 
     return this_pcrs, next_pcrs
 
@@ -97,7 +78,7 @@ def compare_pcrs(hash_alg: str, this_pcrs: PcrBank, next_pcrs: PcrBank, wanted_p
         if real_pcrs[idx] == this_pcrs[idx]:
             status = "+"
         else:
-            errors |= True
+            errors = True
             status = "<BAD>"
         logger.info("PCR %2d: %s | %s %s", idx, to_hex(real_pcrs[idx]), to_hex(this_pcrs[idx]), status)
 

--- a/tpm_futurepcr/util.py
+++ b/tpm_futurepcr/util.py
@@ -44,12 +44,6 @@ def guid_to_UUID(buf):
     return uuid.UUID(bytes=buf)
 
 
-def hash_bytes(buf, alg="sha1"):
-    h = hashlib.new(alg)
-    h.update(buf)
-    return h.digest()
-
-
 def hash_file(path, alg="sha1"):
     h = hashlib.new(alg)
     with open(path, "rb") as fh:


### PR DESCRIPTION
This PR finishes (I think?) with the encapsulation of events into classes. I'd like to remove the 'type' attribute for the classes that are completely defined, but I am looking for an elegant way of doing it. I have also fixed some single quotes that were used on strings instead of double quotes.