### PR TITLE
Avoid an exception in device_path_to_unix_path

### DIFF
--- a/tpm_futurepcr/__init__.py
+++ b/tpm_futurepcr/__init__.py
@@ -104,7 +104,7 @@ def main():
                 errors = 1
                 unix_path = None
 
-            if unix_path:
+            if unix_path and os.path.exists(unix_path):
                 file_hash = hash_pecoff(unix_path, hash_alg)
                 next_extend_value = file_hash
                 last_efi_binary = unix_path

--- a/tpm_futurepcr/device_path.py
+++ b/tpm_futurepcr/device_path.py
@@ -76,7 +76,7 @@ def device_path_to_unix_path(path_vec):
                 dir_path = find_mountpoint_by_partuuid(pp.part_uuid)
                 if not dir_path:
                     raise Exception("could not find mountpoint for partuuid %r" % pp.part_uuid)
-            if pp.subtype == MediaDevicePathSubtype.FilePath:
+            if pp.subtype == MediaDevicePathSubtype.FilePath and dir_path is not None:
                 file_path = pp.file_path
                 unix_path = dir_path + file_path.replace("\\", "/").rstrip("\0")
         if pp.type == DevicePathType.End:

--- a/tpm_futurepcr/device_path.py
+++ b/tpm_futurepcr/device_path.py
@@ -76,9 +76,12 @@ def device_path_to_unix_path(path_vec):
                 dir_path = find_mountpoint_by_partuuid(pp.part_uuid)
                 if not dir_path:
                     raise Exception("could not find mountpoint for partuuid %r" % pp.part_uuid)
-            if pp.subtype == MediaDevicePathSubtype.FilePath and dir_path is not None:
-                file_path = pp.file_path
-                unix_path = dir_path + file_path.replace("\\", "/").rstrip("\0")
+            if pp.subtype == MediaDevicePathSubtype.FilePath:
+                if dir_path is not None:
+                    file_path = pp.file_path
+                    unix_path = dir_path + file_path.replace("\\", "/").rstrip("\0")
+                else:
+                    unix_path = pp.file_path.replace("\\", "/").rstrip("\0")
         if pp.type == DevicePathType.End:
             break
     return unix_path


### PR DESCRIPTION
Don't try to use dir_path if it is None.  This avoids the exception:

    unsupported operand type(s) for +: 'NoneType' and 'str'